### PR TITLE
Changed all non-Ziplink routes to include ~prefix

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,7 +19,7 @@ app.use(logger('dev'));
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(cookieParser());
-app.use(express.static(path.join(__dirname, 'public')));
+app.use('/~static', express.static(path.join(__dirname, 'public')));
 
 app.use('/', indexRoute);
 

--- a/routes/index.js
+++ b/routes/index.js
@@ -7,11 +7,11 @@ var Ziplink = require('ziplink-basic-mongo-storage');
 var newRoute = require('./new.js');
 var debugRoute = require('./debug.js');
 
-router.use('/new', newRoute);
+router.use('/~new', newRoute);
 
 //If NODE_ENV is undefined or 'development', use the debug route
 if ((process.env.NODE_ENV || 'development') == 'development')
-	router.use('/debug', debugRoute);
+	router.use('/~debug', debugRoute);
 
 /* Render homepage */
 router.get('/', function(req, res, next) {
@@ -19,6 +19,12 @@ router.get('/', function(req, res, next) {
 	err.status = 404;
 	err.message = "Homepage not yet implemented";
 	next(err);
+});
+
+router.get('/~:ID', function(req, res, next){
+  var err = new Error('Utility page \'/~' + req.params.ID + '\' not found');
+  err.status = 404;
+  next(err);
 });
 
 /*	Ziplink display page */

--- a/views/includes/head.ejs
+++ b/views/includes/head.ejs
@@ -19,9 +19,9 @@
 
   <!-- CSS
   –––––––––––––––––––––––––––––––––––––––––––––––––– -->
-  <link rel="stylesheet" href="/stylesheets/normalize.css">
-  <link rel="stylesheet" href="/stylesheets/skeleton.css">
-  <link rel="stylesheet" href="/stylesheets/style.css">
+  <link rel="stylesheet" href="/~static/stylesheets/normalize.css">
+  <link rel="stylesheet" href="/~static/stylesheets/skeleton.css">
+  <link rel="stylesheet" href="/~static/stylesheets/style.css">
 
   <!-- Favicon
   –––––––––––––––––––––––––––––––––––––––––––––––––– 
@@ -31,7 +31,7 @@
   <!-- Scripts
   –––––––––––––––––––––––––––––––––––––––––––––––––– -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
-  <script src='/scripts/ziplink.js'></script>
+  <script src='/~static/scripts/ziplink.js'></script>
 
 </head>
 <body>

--- a/views/newZiplink.ejs
+++ b/views/newZiplink.ejs
@@ -2,7 +2,7 @@
 
   <!-- Temporary testing form -->
 
-  	<form action="/new" method="post">
+  	<form action="/~new" method="post">
   		<label for="name">Name</label>
   		<input type="text" id="name" name="name">
   		<label for="sublinks0">sublinks[0]</label>


### PR DESCRIPTION
Resolves #10, ziplink IDs can only contain a..z,A..Z,0..9, collisions with utility routes no longer possible
